### PR TITLE
fix: use reobfuscated JAR for Legacy Forge during publishing

### DIFF
--- a/build-logic/src/main/kotlin/ModPlatformPlugin.kt
+++ b/build-logic/src/main/kotlin/ModPlatformPlugin.kt
@@ -284,7 +284,14 @@ abstract class ModPlatformPlugin @Inject constructor() : Plugin<Project> {
 				dryRun = true
 			}
 
-			val jarTask = tasks.named(ext.jarTask.get()).map { it as Jar }
+			val isForge = loader == "forge"
+			val targetName = if(isForge) {
+				"reobfJar"
+			} else {
+				ext.jarTask.get()
+			}
+
+			val jarTask = tasks.named(targetName).map { it as Jar }
 			val srcJarTask = tasks.named(ext.sourcesJarTask.get()).map { it as Jar }
 			val currentVersion = stonecutter.current.version
 			val deps = ext.dependencies


### PR DESCRIPTION
Fixes issue #5 