### PR TITLE
New optional system for mixin declaration

### DIFF
--- a/build-logic/src/main/kotlin/MixinUtils.kt
+++ b/build-logic/src/main/kotlin/MixinUtils.kt
@@ -1,0 +1,58 @@
+@file:Suppress("unused")
+
+import dev.kikugie.stonecutter.build.StonecutterBuildExtension
+import org.gradle.api.logging.Logger
+
+fun List<String>.toMixinJsonArray(): String {
+	if (isEmpty()) return "[]"
+	return joinToString(",\n    ", prefix = "[\n    ", postfix = "\n  ]") { "\"$it\"" }
+}
+
+fun resolveMixinsForVersion(
+	sideConfig: MixinsSideConfig,
+	mcVersion: String,
+	stonecutter: StonecutterBuildExtension
+): List<String> {
+	val result = mutableListOf<String>()
+
+	for (group in sideConfig.definitions) {
+		val shouldInclude = when (group) {
+			is MixinGroup.Always -> true
+			is MixinGroup.MinVersion -> stonecutter.compare(mcVersion, group.min) >= 0
+			is MixinGroup.MaxVersion -> stonecutter.compare(mcVersion, group.max) <= 0
+			is MixinGroup.VersionRange ->
+				stonecutter.compare(mcVersion, group.min) >= 0 &&
+					stonecutter.compare(mcVersion, group.max) <= 0
+			is MixinGroup.ExactVersion -> stonecutter.compare(mcVersion, group.version) == 0
+		}
+
+		if (shouldInclude) {
+			result.addAll(group.mixins)
+		}
+	}
+
+	return result.distinct()
+}
+
+fun MixinsExtension.hasAnyMixins(): Boolean {
+	return common.definitions.isNotEmpty() ||
+		client.definitions.isNotEmpty() ||
+		server.definitions.isNotEmpty()
+}
+
+fun logMixinConfiguration(
+	logger: Logger,
+	mcVersion: String,
+	commonCount: Int,
+	clientCount: Int,
+	serverCount: Int
+) {
+	logger.lifecycle("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	logger.lifecycle("🎯 Dynamic Mixin System Detected")
+	logger.lifecycle("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	logger.lifecycle("  📦 Minecraft Version: $mcVersion")
+	logger.lifecycle("  🔧 Common Mixins:     $commonCount")
+	logger.lifecycle("  💻 Client Mixins:     $clientCount")
+	logger.lifecycle("  🖥️  Server Mixins:     $serverCount")
+	logger.lifecycle("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+}

--- a/build-logic/src/main/kotlin/MixinsExtension.kt
+++ b/build-logic/src/main/kotlin/MixinsExtension.kt
@@ -1,0 +1,59 @@
+@file:Suppress("unused")
+
+import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import javax.inject.Inject
+
+abstract class MixinsExtension @Inject constructor(objects: ObjectFactory) {
+
+	val common: MixinsSideConfig = objects.newInstance(MixinsSideConfig::class.java)
+	val client: MixinsSideConfig = objects.newInstance(MixinsSideConfig::class.java)
+	val server: MixinsSideConfig = objects.newInstance(MixinsSideConfig::class.java)
+
+	fun common(action: Action<MixinsSideConfig>) {
+		action.execute(common)
+	}
+
+	fun client(action: Action<MixinsSideConfig>) {
+		action.execute(client)
+	}
+
+	fun server(action: Action<MixinsSideConfig>) {
+		action.execute(server)
+	}
+}
+
+abstract class MixinsSideConfig @Inject constructor() {
+
+	internal val definitions = mutableListOf<MixinGroup>()
+
+	fun always(vararg mixins: String) {
+		definitions.add(MixinGroup.Always(mixins.toList()))
+	}
+
+	fun minVersion(minVersion: String, vararg mixins: String) {
+		definitions.add(MixinGroup.MinVersion(minVersion, mixins.toList()))
+	}
+
+	fun maxVersion(maxVersion: String, vararg mixins: String) {
+		definitions.add(MixinGroup.MaxVersion(maxVersion, mixins.toList()))
+	}
+
+	fun versionRange(minVersion: String, maxVersion: String, vararg mixins: String) {
+		definitions.add(MixinGroup.VersionRange(minVersion, maxVersion, mixins.toList()))
+	}
+
+	fun exactVersion(version: String, vararg mixins: String) {
+		definitions.add(MixinGroup.ExactVersion(version, mixins.toList()))
+	}
+}
+
+sealed class MixinGroup {
+	abstract val mixins: List<String>
+
+	data class Always(override val mixins: List<String>) : MixinGroup()
+	data class MinVersion(val min: String, override val mixins: List<String>) : MixinGroup()
+	data class MaxVersion(val max: String, override val mixins: List<String>) : MixinGroup()
+	data class VersionRange(val min: String, val max: String, override val mixins: List<String>) : MixinGroup()
+	data class ExactVersion(val version: String, override val mixins: List<String>) : MixinGroup()
+}

--- a/build-logic/src/main/kotlin/ModPlatformPlugin.kt
+++ b/build-logic/src/main/kotlin/ModPlatformPlugin.kt
@@ -67,6 +67,8 @@ abstract class ModPlatformPlugin @Inject constructor() : Plugin<Project> {
 			sourcesJarTask.convention(inferredLoader.sourcesJarTask)
 		}
 
+		extensions.create("mixins", MixinsExtension::class.java)
+		
 		listOf("org.jetbrains.kotlin.jvm", "com.google.devtools.ksp", "dev.kikugie.fletching-table").forEach {
 			apply(
 				plugin = it

--- a/build-logic/src/main/kotlin/ModPlatformPlugin.kt
+++ b/build-logic/src/main/kotlin/ModPlatformPlugin.kt
@@ -142,10 +142,61 @@ abstract class ModPlatformPlugin @Inject constructor() : Plugin<Project> {
 	private fun Project.configureProcessResources(ctx: Context) {
 		tasks.named<ProcessResources>("processResources") {
 			dependsOn(tasks.named("stonecutterGenerate"), "kspKotlin")
-			filesMatching("*.mixins.json") {
-				expand("java" to "JAVA_${ctx.javaVersion.majorVersion}")
+
+			val mcVersion = ctx.stonecutter.current.version.split("-")[0]
+			val mixinsExt = project.extensions.findByType<MixinsExtension>()
+
+			if (mixinsExt != null && mixinsExt.hasAnyMixins()) {
+				val commonMixins = resolveMixinsForVersion(mixinsExt.common, mcVersion, ctx.stonecutter)
+				val clientMixins = resolveMixinsForVersion(mixinsExt.client, mcVersion, ctx.stonecutter)
+				val serverMixins = resolveMixinsForVersion(mixinsExt.server, mcVersion, ctx.stonecutter)
+
+				val commonArray = commonMixins.toMixinJsonArray()
+				val clientArray = clientMixins.toMixinJsonArray()
+				val serverArray = serverMixins.toMixinJsonArray()
+
+				logMixinConfiguration(
+					logger = project.logger,
+					mcVersion = mcVersion,
+					commonCount = commonMixins.size,
+					clientCount = clientMixins.size,
+					serverCount = serverMixins.size
+				)
+
+				processMixinFiles(ctx, mapOf(
+					"java" to "JAVA_${ctx.javaVersion.majorVersion}",
+					"common_array" to commonArray,
+					"client_array" to clientArray,
+					"server_array" to serverArray
+				))
+
+				inputs.property("mcVersion", mcVersion)
+				inputs.property("commonMixins", commonArray)
+				inputs.property("clientMixins", clientArray)
+				inputs.property("serverMixins", serverArray)
+			} else {
+				processMixinFiles(ctx, mapOf(
+					"java" to "JAVA_${ctx.javaVersion.majorVersion}"
+				))
 			}
+
 			exclude(ctx.loader.excludedResources)
+		}
+	}
+
+	private fun ProcessResources.processMixinFiles(ctx: Context, expansionMap: Map<String, String>) {
+		filesMatching("*.mixins.json") {
+			expand(expansionMap)
+
+			if (ctx.loader is Loader.Forge) {
+				filter { line ->
+					if (line.contains("\"package\"") && line.trim().endsWith(",")) {
+						line + "\n    \"refmap\": \"${ctx.modId}.mixins.refmap.json\","
+					} else {
+						line
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
As I mentioned in #10 , this is where said implementation would be.
- A reference to the refmap has been added to the mixin file to prevent errors in Forge
- A new system has been added to declare how mixins are added to the mixin.json file (The idea behind this is that the fletching-table plugin, when it changes frequently between versions, ends up corrupting its cache, causing it to omit some mixins and other errors)

Example of use:
<img width="1032" height="884" alt="carbon" src="https://github.com/user-attachments/assets/cfa7f0e3-fc93-4813-a08c-fb35150abc85" />
