### PR TITLE
feat: add versioned access transformers to neo/forge manifest

### DIFF
--- a/build-logic/src/main/kotlin/Loader.kt
+++ b/build-logic/src/main/kotlin/Loader.kt
@@ -117,7 +117,8 @@ sealed class Loader(val id: String) {
 						credits = "${ctx.authors.joinToString(", ")} Contributors: ${ctx.contributors.joinToString(", ")}",
 						description = ctx.description
 					)
-				), dependencies = mapOf(ctx.modId to forgeDeps), mixins = listOf(ForgeMixin("${ctx.modId}.mixins.json"))
+				), dependencies = mapOf(ctx.modId to forgeDeps), mixins = listOf(ForgeMixin("${ctx.modId}.mixins.json")),
+				accessTransformers = listOf(ForgeAccessTransformer("aw/${ctx.stonecutter.current.version}.cfg"))
 			)
 
 			return TOML.encodeToString(manifest)

--- a/build-logic/src/main/kotlin/LoaderMetadata.kt
+++ b/build-logic/src/main/kotlin/LoaderMetadata.kt
@@ -32,7 +32,8 @@ data class ForgeManifest(
 	val issueTrackerURL: String,
 	val mods: List<ForgeMod>,
 	val dependencies: Map<String, List<ForgeDependency>> = emptyMap(),
-	val mixins: List<ForgeMixin> = emptyList()
+	val mixins: List<ForgeMixin> = emptyList(),
+	val accessTransformers: List<ForgeAccessTransformer> = emptyList()
 )
 
 @Serializable
@@ -60,3 +61,6 @@ data class ForgeDependency(
 
 @Serializable
 data class ForgeMixin(val config: String)
+
+@Serializable
+data class ForgeAccessTransformer(val file: String)


### PR DESCRIPTION
Neo/forge only checks the default location for access transformer files, so the versioned AT files have to be specified in the mods.toml, or else the ATs will not apply in a production environment.