### PR TITLE
fix: discord url showing up as empty when omitted

### DIFF
--- a/build-logic/src/main/kotlin/Loader.kt
+++ b/build-logic/src/main/kotlin/Loader.kt
@@ -9,7 +9,7 @@ import net.peanuuutz.tomlkt.Toml
 import org.gradle.api.NamedDomainObjectContainer
 import java.util.*
 
-private val JSON = Json { prettyPrint = true; encodeDefaults = true }
+private val JSON = Json { prettyPrint = true; encodeDefaults = true; explicitNulls = false }
 private val TOML = Toml { }
 
 sealed class Loader(val id: String) {
@@ -38,10 +38,12 @@ sealed class Loader(val id: String) {
 				contact = mapOf(
 					"sources" to ctx.sourcesUrl, "issues" to ctx.issuesUrl, "homepage" to ctx.homepageUrl
 				),
-				custom = buildJsonObject {
-					putJsonObject("modmenu") {
-						putJsonObject("links") {
-							put("modmenu.discord", ctx.discordUrl)
+				custom = ctx.discordUrl.takeIf { it.isNotEmpty() }?.let { url ->
+					buildJsonObject {
+						putJsonObject("modmenu") {
+							putJsonObject("links") {
+								put("modmenu.discord", url)
+							}
 						}
 					}
 				},
@@ -105,7 +107,9 @@ sealed class Loader(val id: String) {
 			addDeps(ctx.extension.dependencies.incompatible, "incompatible")
 
 			val manifest = ForgeManifest(
-				license = ctx.licenseName, issueTrackerURL = ctx.issuesUrl, mods = listOf(
+				license = ctx.licenseName,
+				issueTrackerURL = ctx.issuesUrl,
+				mods = listOf(
 					ForgeMod(
 						modId = ctx.modId,
 						displayName = ctx.modName,
@@ -117,7 +121,9 @@ sealed class Loader(val id: String) {
 						credits = "${ctx.authors.joinToString(", ")} Contributors: ${ctx.contributors.joinToString(", ")}",
 						description = ctx.description
 					)
-				), dependencies = mapOf(ctx.modId to forgeDeps), mixins = listOf(ForgeMixin("${ctx.modId}.mixins.json")),
+				),
+				dependencies = mapOf(ctx.modId to forgeDeps),
+				mixins = listOf(ForgeMixin("${ctx.modId}.mixins.json")),
 				accessTransformers = listOf(ForgeAccessTransformer("aw/${ctx.stonecutter.current.version}.cfg"))
 			)
 

--- a/build-logic/src/main/kotlin/LoaderMetadata.kt
+++ b/build-logic/src/main/kotlin/LoaderMetadata.kt
@@ -10,7 +10,7 @@ data class FabricManifest(
 	val authors: List<String>,
 	val contributors: List<String>,
 	val contact: Map<String, String>,
-	val custom: JsonObject,
+	val custom: JsonObject?,
 	val description: String,
 	val icon: String,
 	val license: String,


### PR DESCRIPTION
Previously if you removed `mod.discord_url` from your `stonecutter.properties.toml` or set to `""`, it would still show up in Mod Menu, and when you clicked on it would show an empty link dialog that does nothing:
<img width="700" height="290" alt="image" src="https://github.com/user-attachments/assets/a4006aeb-5161-45b9-adc4-fb06c2171948" />

This PR fixes that by omitting the `custom` field of `fabric.mod.json` when the discord url is empty.