### PR TITLE
fix: incorrect version for selecting Java version

### DIFF
--- a/build-logic/src/main/kotlin/Context.kt
+++ b/build-logic/src/main/kotlin/Context.kt
@@ -62,7 +62,7 @@ class Context(
 	val javaVersion: JavaVersion by lazy {
 		when {
 			stonecutter.eval(currentMcVersion, ">=26") -> JavaVersion.VERSION_25
-			stonecutter.eval(currentMcVersion, ">=1.20.6") -> JavaVersion.VERSION_21
+			stonecutter.eval(currentMcVersion, ">=1.20.5") -> JavaVersion.VERSION_21
 			stonecutter.eval(currentMcVersion, ">=1.18") -> JavaVersion.VERSION_17
 			stonecutter.eval(currentMcVersion, ">=1.17") -> JavaVersion.VERSION_16
 			else -> JavaVersion.VERSION_1_8


### PR DESCRIPTION
Java 21 was introduced in [Minecraft 1.20.5](https://minecraft.wiki/w/Java_Edition_1.20.5#cite_ref-3), not 1.20.6.