### PR TITLE
fix: gitignore ignoring files in `.idea/` which are supposed to be included

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,12 @@ bin/
 .DS_Store
 
 ### Jetbrains ###
-.idea/
+.idea/*
 !.idea/icon.png
 !.idea/externalDependencies.xml
 !.idea/icon.svg
+
+!.idea/runConfigurations
+.idea/runConfigurations/*
 !.idea/runConfigurations/Run_Active_Client.xml
 !.idea/runConfigurations/Run_Active_Server.xml


### PR DESCRIPTION
Previously, the entire `.idea` folder would be excluded, including files that were supposed to be included, if you removed this templates git history and made a new repository with it.

This is because `.idea/` always ignores the entire folder, even if there were unignores later. You have to use `/*` and some other shenanigans for subdirectories (see https://stackoverflow.com/a/5534865).