### PR TITLE
fix; #20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,16 @@ info("Updating stonecutter.properties.toml ...")
 
 props_text = read(PROPS_FILE)
 
+# Preserve loomx.loom_version (and any other top-level loomx.* lines) if present
+loomx_lines = []
+for line in props_text.splitlines():
+    stripped = line.strip()
+    if stripped.startswith("loomx."):
+        loomx_lines.append(stripped)
+    elif stripped and not stripped.startswith("#") and "=" in stripped and not stripped.startswith("mod.") and not stripped.startswith("[["):
+        # stop at first non-loomx, non-comment content that looks like a key=value
+        break
+
 match = re.search(r"^\[fabric\]", props_text, re.MULTILINE)
 if not match:
     abort("Could not find [fabric] section in stonecutter.properties.toml.")
@@ -199,7 +209,10 @@ pom_devs = "\n".join(
     for a in authors
 )
 
+loomx_block = ("\n".join(loomx_lines) + "\n\n") if loomx_lines else ""
+
 new_props = f"""\
+{loomx_block}
 mod.id = "{mod_id}"
 mod.name = "{mod_name}"
 mod.group = "{mod_group}"


### PR DESCRIPTION
Fix: setup.py was rewriting stonecutter.properties.toml from the [fabric] section onward, dropping the top-level loomx.loom_version line and breaking Gradle.
Change: Capture any loomx.* lines at the top of the file and write them back before the mod properties so they are preserved.
#20 