### PR TITLE
Fix: stonecutter.properties -> fabric on mc 1.21.1 has incompatible dependency of modmenu set to 15.0, 11.0.4 is the correct version

### DIFF
--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -37,7 +37,7 @@ deps.modmenu = "4.2.0-beta.2"
 [fabric."1.21.1"]
 deps.minecraft = "1.21.1"
 deps.fabric-api = "0.116.7+1.21.1"
-deps.modmenu = "15.0.0"
+deps.modmenu = "11.0.4"
 
 [fabric."1.21.7"]
 deps.minecraft = "1.21.7"


### PR DESCRIPTION
fixes default template using modmenu 15.0.0 on fabric for mc version 1.21.1 which results in an incompatibility error at launch, now it's set to the latest available for 1.21.1 ie: 11.0.4
<img width="786" height="473" alt="Screenshot 2026-08-10 200258" src="https://github.com/user-attachments/assets/ae1d19f7-53eb-4bc5-a657-b2ba1c1aeb09" />
