### PR TITLE
fix: enable Gradle configuration cache and provision toolchain JDKs

### DIFF
--- a/build-logic/src/main/kotlin/ModPlatformPlugin.kt
+++ b/build-logic/src/main/kotlin/ModPlatformPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Property
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
@@ -106,6 +107,9 @@ abstract class ModPlatformPlugin @Inject constructor() : Plugin<Project> {
 			withJavadocJar()
 			sourceCompatibility = ctx.javaVersion
 			targetCompatibility = ctx.javaVersion
+			toolchain {
+				languageVersion.set(JavaLanguageVersion.of(ctx.javaVersion.majorVersion))
+			}
 		}
 	}
 
@@ -135,12 +139,14 @@ abstract class ModPlatformPlugin @Inject constructor() : Plugin<Project> {
 	}
 
 	private fun Project.configureProcessResources(ctx: Context) {
+		val javaVersionValue = "JAVA_${ctx.javaVersion.majorVersion}"
+		val excluded = ctx.loader.excludedResources
 		tasks.named<ProcessResources>("processResources") {
 			dependsOn(tasks.named("stonecutterGenerate"), "kspKotlin")
 			filesMatching("*.mixins.json") {
-				expand("java" to "JAVA_${ctx.javaVersion.majorVersion}")
+				expand("java" to javaVersionValue)
 			}
-			exclude(ctx.loader.excludedResources)
+			exclude(excluded)
 		}
 	}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true


### PR DESCRIPTION
- gradle.properties: enable org.gradle.configuration-cache.
- fix in configureProcessResources to work with configuration-cache
- configureJava: declare a toolchain from ctx.javaVersion so Gradle gets the right JDK per version