### PR TITLE
fix: NeoForge 26.2+ logo warning

### DIFF
--- a/build-logic/src/main/kotlin/Loader.kt
+++ b/build-logic/src/main/kotlin/Loader.kt
@@ -108,6 +108,7 @@ sealed class Loader(val id: String) {
 						displayURL = ctx.homepageUrl,
 						modUrl = ctx.homepageUrl,
 						logoFile = "assets/icon.png",
+						iconFile = "assets/icon.png", // NeoForge 26.2 +
 						authors = ctx.authors.joinToString(", "),
 						credits = "${ctx.authors.joinToString(", ")} Contributors: ${ctx.contributors.joinToString(", ")}",
 						description = ctx.description

--- a/build-logic/src/main/kotlin/LoaderMetadata.kt
+++ b/build-logic/src/main/kotlin/LoaderMetadata.kt
@@ -45,6 +45,7 @@ data class ForgeMod(
 	val displayURL: String,
 	val modUrl: String,
 	val logoFile: String,
+	val iconFile: String,
 	val authors: String,
 	val logoBlur: Boolean = false,
 	val credits: String,


### PR DESCRIPTION
fixes #25

Note: NeoForge also introduced a new "bannerFile" field (larger, usually wider image shown above the mod info when selected in the list), which I didn't add support for here